### PR TITLE
Use capsule shaped collision shape

### DIFF
--- a/player.tscn
+++ b/player.tscn
@@ -6,8 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://bkj08x1vxwemw" path="res://peter_laugh.tscn" id="4_j4yg8"]
 [ext_resource type="PackedScene" uid="uid://hji4tc528rsb" path="res://pause_menu.tscn" id="5_8jyi3"]
 
-[sub_resource type="BoxShape3D" id="BoxShape3D_8t60p"]
-size = Vector3(0.5, 0.352, 1.146)
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_kegfr"]
 
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_5jgtd"]
 properties/0/path = NodePath(".:position")
@@ -34,8 +33,8 @@ script = ExtResource("1_v0x33")
 transform = Transform3D(-0.0599629, 0, 0.00210966, 0, 0.06, 0, -0.00210966, 0, -0.0599629, 0, 0.0579519, -0.00402367)
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 0.536464, 0, 0, 0, 1, -0.000157759, 0.236106, -0.0651288)
-shape = SubResource("BoxShape3D_8t60p")
+transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, -0.000157759, 0.236106, -0.0101096)
+shape = SubResource("CapsuleShape3D_kegfr")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(0.999687, 0.00242358, -0.0248818, 0.000888677, 0.991216, 0.132253, 0.0249837, -0.132234, 0.990904, 0.284397, 0.432129, 0.342452)


### PR DESCRIPTION
Change the existing box shaped collision shape to a capsule. This is more common practice in collision for 3D actors and prevents strange clipping issues (sometimes).